### PR TITLE
Improve Github actions workflows

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -1,4 +1,5 @@
-name: unit tests
+name: e2e tests
+
 on:
   push:
     branches: [ main ]
@@ -19,8 +20,5 @@ jobs:
         with:
           go-version: ${{ matrix.go-version }}
 
-      - name: Build
-        run: go build cmd
-
-      - name: Run unit tests
-        run: go test -v ./...
+      - name: E2E tests
+        run: make test

--- a/.github/workflows/verify-attribution.yaml
+++ b/.github/workflows/verify-attribution.yaml
@@ -1,0 +1,37 @@
+name: verify attribution
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  verify-attribution:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: '1.22'
+
+    - name: Build attribution-gen
+      run: make build
+
+    - name: Run attribution-gen
+      run: ./bin/attribution-gen --output generated_attribution.md
+
+    - name: Compare ATTRIBUTION.md files
+      run: |
+        if cmp -s ATTRIBUTION.md generated_attribution.md; then
+          echo "ATTRIBUTION.md is up to date"
+        else
+          echo "ATTRIBUTION.md is not up to date. Please regenerate it."
+          exit 1
+        fi
+
+    - name: Clean up
+      if: always()
+      run: rm -f attribution-gen generated_attribution.md


### PR DESCRIPTION
This patch revises our Github actions configurations. First, the unit
test workflow now uses Go 1.22 and 1.21, removing older versions. We've
also added a new e2e test workflow to fully test the binary functionality.
This patch also adds a new workflow that verifies the existing
`ATTRIBUTION.md` file to keep our attribution information accurate.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
