### PR TITLE
Add flag --allow-mod-not-found to skip modules that weren't found

### DIFF
--- a/cmd/goproxy.go
+++ b/cmd/goproxy.go
@@ -29,6 +29,7 @@ const (
 
 var (
 	ErrInvalidEscapedModulePath = errors.New("invalid escaped module path")
+	ErrModuleNotFound           = errors.New("module not found in proxy")
 )
 
 // downloadModule downloads the content a given module path/version.
@@ -51,6 +52,9 @@ func downloadModule(module *module.Version) ([]byte, error) {
 	if resp.StatusCode == 410 && strings.Contains(string(body), "invalid escaped module path") {
 		return nil, ErrInvalidEscapedModulePath
 	}
+	if resp.StatusCode == 404 {
+		return nil, ErrModuleNotFound
+	}
 
-	return nil, fmt.Errorf("unhanled response status code: %v", resp.StatusCode)
+	return nil, fmt.Errorf("unhandled response status code: %v", resp.StatusCode)
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -39,6 +39,7 @@ var (
 	traceOpt                          bool
 	testOpt                           bool
 	showGraphOpt                      bool
+	allowModuleNotFoundOpt            bool
 )
 
 func init() {
@@ -46,6 +47,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&traceOpt, "trace", false, "Show trace output")
 	rootCmd.PersistentFlags().BoolVar(&debugOpt, "debug", false, "Show debug output")
 	rootCmd.PersistentFlags().BoolVar(&showGraphOpt, "show-graph", false, "Show the dependency graph in stdout")
+	rootCmd.PersistentFlags().BoolVar(&allowModuleNotFoundOpt, "allow-mod-not-found", false, "Allows modules that aren't found in the proxy to be skipped")
 	rootCmd.PersistentFlags().IntVar(&depthOpt, "depth", defaultDepth, "Depth of the dependency tree to explore")
 	rootCmd.PersistentFlags().StringVar(&goProxyURLOpt, "go-proxy-url", defaultGoProxyURL, "Go proxy used to fetch module versions and licenses")
 	rootCmd.PersistentFlags().StringVar(
@@ -97,7 +99,7 @@ func generateAttributionsFile(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	tree, err := gb.buildGraph(goMod, depthOpt)
+	tree, err := gb.buildGraph(goMod, depthOpt, allowModuleNotFoundOpt)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
*Description of changes:*

This PR adds a new flag `--allow-mod-not-found` which allows skipping over module not found errors (http 404) from failing the attribution generation. This is similar to the skip that already happens when a license cannot be identified within a module, however this behavior to skip over a not found module is disabled by default and only enabled when the cli flag is provided.

Manually tested

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
